### PR TITLE
docs: Update README with Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Current and planned features:
 
 1. Try to run the botrunner with `cargo run` in the `gameserver` directory. It should compile, but fail to play a match.
 1. Run the botrunner again (still in the `gameserver` directory) with:
-    * Linux -  `cargo run ..\planetwars\config_examples\stub.config.json`
+    * Linux -  `cargo run ../planetwars/config_examples/stub.config.json`
     * Windows -  `cargo run ..\planetwars\config_examples\stub.config_windows.json`
 1. It should have generated a log-file `log.json`.
 1. If it did, great, it works! Check setup below for the client.

--- a/README.md
+++ b/README.md
@@ -34,26 +34,28 @@ Current and planned features:
 ### Gameserver
 
 1. Install rust and cargo (take look [here](https://rustup.rs/) if you're using an older software repository such as Ubuntu apt).
-- Rust >= 1.18.0
-- Cargo >= 0.16.0
+    * Rust >= 1.18.0
+    * Cargo >= 0.16.0
 
 1. Try to run the botrunner with `cargo run` in the `gameserver` directory. It should compile, but fail to play a match.
-1. Run the botrunner again with `cargo run ..\planetwars\config_examples\stub.config.json` (still in the `gameserver` directory).
+1. Run the botrunner again (still in the `gameserver` directory) with:
+    * Linux -  `cargo run ..\planetwars\config_examples\stub.config.json`
+    * Windows -  `cargo run ..\planetwars\config_examples\stub.config_windows.json`
 1. It should have generated a log-file `log.json`.
 1. If it did, great, it works! Check setup below for the client.
 
 ### Client
 
-Note: Do the setup for the gameserver first
+**Note:** Do the setup for the gameserver first
 
 1. Install Node v8 and npm.
 1. Go the `planetwars\client` directory
 1. Install dependencies with `npm install`.
-1. Go the `.\bin` dir and symlink the gameserver with `ln -s ../../../gameserver/target/release/mozaic_bot_driver`.
+1. Go the `.\bin` dir and symlink the gameserver with:
+    * Linux -  `ln -s ../../../gameserver/target/release/mozaic_bot_driver`
+    * Windows -  `mklink bot_driver.exe ..\..\..\gameserver\target\release\mozaic_bot_driver.exe`
 1. Go back the `client` dir and run `npm run dev`.
 1. An electron client should be at your disposal!
-
-We should support Windows, for the symlink run this instead: `mklink bot_driver.exe ..\..\..\gameserver\target\release\mozaic_bot_driver.exe`
 
 ## Contact
 

--- a/planetwars/config_examples/stub.config_windows.json
+++ b/planetwars/config_examples/stub.config_windows.json
@@ -1,0 +1,19 @@
+{
+    "players": [
+        {
+            "name": "bert",
+            "command": "python",
+            "args": ["../planetwars/bots/simplebot/simple.py"]
+        },
+        {
+            "name": "timp",
+            "command": "python",
+            "args": ["../planetwars/bots/simplebot/simple.py"]
+        }
+    ],
+    "game_config": {
+        "map_file": "../planetwars/maps/hex.json",
+        "max_turns": 500
+    },
+    "log_file": "gamelog.json"
+}


### PR DESCRIPTION
This relates to #154 

Added new config file for Windows users that uses `python` command instead of `python3`. The `python3` command will result in errors on Windows.

Updated README with instructions for Windows users. Modified the Gameserver section so that it doesn't re-start numbering.